### PR TITLE
Init proxy handler

### DIFF
--- a/config
+++ b/config
@@ -7,3 +7,8 @@ path /f StaticFileHandler {
 path /f/bar EchoHandler {}
 
 path /status StatusHandler {}
+
+path /proxy ProxyHandler {
+	host localhost;
+	port 5678;
+}

--- a/src/ProxyHandler.cc
+++ b/src/ProxyHandler.cc
@@ -19,19 +19,19 @@ RequestHandler::Status ProxyHandler::Init(const std::string& uri_prefix,
 
     // Get remote host and post from config.
     if (config.statements_.size() >= 2) {
-    	for (auto const& statement: config.statements_) {
-    		std::vector<std::string> tokens = statement->tokens_;
-    		if (tokens.size() == 2) {
-    			if (tokens.at(0) == HOST_TOKEN) {
-    				host_ = tokens.at(1);
-    			}
-    			else if (tokens.at(0) == PORT_TOKEN) {
-    				port_ = tokens.at(1);
-    			}
-    		}
-    	}
-    	BOOST_LOG_TRIVIAL(info) << "Init ProxyHandler " << "host: " << host_ << ", port: " << port_ << "\n";
-    	return OK;
+        for (auto const& statement: config.statements_) {
+            std::vector<std::string> tokens = statement->tokens_;
+            if (tokens.size() == 2) {
+                if (tokens.at(0) == HOST_TOKEN) {
+                    host_ = tokens.at(1);
+                }
+                else if (tokens.at(0) == PORT_TOKEN) {
+                    port_ = tokens.at(1);
+                }
+            }
+        }
+        BOOST_LOG_TRIVIAL(info) << "Init ProxyHandler " << "host: " << host_ << ", port: " << port_ << "\n";
+        return OK;
     }
     BOOST_LOG_TRIVIAL(error) << "Init ProxyHandler: bad config\n";
     return NOT_ENOUGH_PARAM;

--- a/src/ProxyHandler.cc
+++ b/src/ProxyHandler.cc
@@ -30,6 +30,25 @@ RequestHandler::Status ProxyHandler::Init(const std::string& uri_prefix,
                 }
             }
         }
+
+        // Error checking on config parameters.
+        if (host_ == "") {
+            BOOST_LOG_TRIVIAL(error) << "No host specified\n";
+            return BAD_CONFIG;
+        }
+        int port_as_int;
+        try {
+            port_as_int = std::stoi(port_);
+        }
+        catch (std::exception const &e) {
+            BOOST_LOG_TRIVIAL(error) << "Port number is not a valid number\n";
+            return BAD_CONFIG;
+        }
+        if (port_as_int > 65535 || port_as_int < 0) {
+            BOOST_LOG_TRIVIAL(error) << "Port is outside acceptable range\n";
+            return BAD_CONFIG;
+        }
+
         BOOST_LOG_TRIVIAL(info) << "Init ProxyHandler " << "host: " << host_ << ", port: " << port_ << "\n";
         return OK;
     }

--- a/src/ProxyHandler.cc
+++ b/src/ProxyHandler.cc
@@ -1,0 +1,38 @@
+#include "ProxyHandler.h"
+
+const std::string HOST_TOKEN = "host";
+const std::string PORT_TOKEN = "port";
+
+RequestHandler::Status ProxyHandler::HandleRequest(const Request& request,
+                     Response* response) {
+    response->SetStatus(Response::ok);
+    response->SetVersion("HTTP/1.0");
+    response->AddHeader("Content-Type", "text/plain");
+    response->SetBody(request.raw_request());
+
+    return RequestHandler::OK;
+}
+
+RequestHandler::Status ProxyHandler::Init(const std::string& uri_prefix,
+            const NginxConfig& config) {
+    uri_prefix_ = uri_prefix;
+
+    // Get remote host and post from config.
+    if (config.statements_.size() >= 2) {
+    	for (auto const& statement: config.statements_) {
+    		std::vector<std::string> tokens = statement->tokens_;
+        	if (tokens.size() == 2) {
+        		if (tokens.at(0) == HOST_TOKEN) {
+            		host_ = tokens.at(1);
+            	}
+            	else if (tokens.at(0) == PORT_TOKEN) {
+            		port_ = tokens.at(1);
+            	}
+        	}
+        }
+        BOOST_LOG_TRIVIAL(info) << "Init ProxyHandler " << "host: " << host_ << ", port: " << port_ << "\n";
+        return OK;
+    }
+    BOOST_LOG_TRIVIAL(error) << "Init ProxyHandler: bad config\n";
+    return NOT_ENOUGH_PARAM;
+}

--- a/src/ProxyHandler.cc
+++ b/src/ProxyHandler.cc
@@ -21,17 +21,17 @@ RequestHandler::Status ProxyHandler::Init(const std::string& uri_prefix,
     if (config.statements_.size() >= 2) {
     	for (auto const& statement: config.statements_) {
     		std::vector<std::string> tokens = statement->tokens_;
-        	if (tokens.size() == 2) {
-        		if (tokens.at(0) == HOST_TOKEN) {
-            		host_ = tokens.at(1);
-            	}
-            	else if (tokens.at(0) == PORT_TOKEN) {
-            		port_ = tokens.at(1);
-            	}
-        	}
-        }
-        BOOST_LOG_TRIVIAL(info) << "Init ProxyHandler " << "host: " << host_ << ", port: " << port_ << "\n";
-        return OK;
+    		if (tokens.size() == 2) {
+    			if (tokens.at(0) == HOST_TOKEN) {
+    				host_ = tokens.at(1);
+    			}
+    			else if (tokens.at(0) == PORT_TOKEN) {
+    				port_ = tokens.at(1);
+    			}
+    		}
+    	}
+    	BOOST_LOG_TRIVIAL(info) << "Init ProxyHandler " << "host: " << host_ << ", port: " << port_ << "\n";
+    	return OK;
     }
     BOOST_LOG_TRIVIAL(error) << "Init ProxyHandler: bad config\n";
     return NOT_ENOUGH_PARAM;

--- a/src/ProxyHandler.h
+++ b/src/ProxyHandler.h
@@ -1,0 +1,23 @@
+#ifndef PROXYHANDLER_H
+#define PROXYHANDLER_H
+
+#include "RequestHandler.h"
+#include "gtest/gtest_prod.h"
+#include "nginx-configparser/config_parser.h"
+#include <boost/log/trivial.hpp>
+
+class ProxyHandler : public RequestHandler {
+public:
+    Status HandleRequest(const Request& request, Response* response);
+    Status Init(const std::string& uri_prefix, const NginxConfig& config);
+
+private:
+    std::string uri_prefix_;
+    std::string host_;
+    std::string port_;
+    FRIEND_TEST(ProxyHandler_test,init_test);
+};
+
+REGISTER_REQUEST_HANDLER(ProxyHandler);
+
+#endif

--- a/src/RequestHandler.h
+++ b/src/RequestHandler.h
@@ -17,7 +17,8 @@ public:
     enum Status {
         OK = 0,
         NOT_FOUND = 1,
-        NOT_ENOUGH_PARAM = 2
+        NOT_ENOUGH_PARAM = 2,
+        BAD_CONFIG = 3
         // Define your status codes here.
     };
     static RequestHandler* CreateByName(const char* type);

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -28,7 +28,10 @@ bool http_server::Init(NginxConfig& config)
                 return false;
             }
             StatusHandler::LogHandler(statement->tokens_[1], statement->tokens_[2]);
-            tmp->Init(statement->tokens_[1], *statement->child_block_.get());
+            RequestHandler::Status status = tmp->Init(statement->tokens_[1], *statement->child_block_.get());
+            if (status != RequestHandler::OK) {
+                return false;
+            }
             BOOST_LOG_TRIVIAL(info) << statement->tokens_[1] << " " << statement->tokens_[2] << "\n";
             handler_mapping_[statement->tokens_[1]] = tmp;
         }

--- a/test/ProxyHandler_test.cc
+++ b/test/ProxyHandler_test.cc
@@ -1,0 +1,29 @@
+#include "gtest/gtest.h"
+
+#include "ProxyHandler.h"
+
+
+class ProxyHandler_test:public ::testing::Test{
+	protected:
+		NginxConfigParser parser;
+};
+
+TEST_F(ProxyHandler_test, init_test){
+	// NginxConfig config;
+	// const char* config_file="config";
+	// parser.Parse(config_file,&config);
+	// EchoHandler handler_;
+	// RequestHandler::Status status=handler_.Init("foo",config);
+	// EXPECT_EQ(handler_.uri_prefix_,"foo");
+	// EXPECT_EQ(status,0);
+}
+
+TEST_F(ProxyHandler_test, handle_request_test){
+	// Response resp;
+	// Request req;
+	// EchoHandler handler_;
+	// RequestHandler::Status status=handler_.HandleRequest(req,&resp);
+	// EXPECT_EQ(resp.response_code_,200);
+	// EXPECT_EQ(status,0);
+}
+


### PR DESCRIPTION
Initializes proxy handler and parses the config file for the host and port number

(right now, HandleRequest will just return an Echo request until the proxy is implemented, and unit tests still need to be written)